### PR TITLE
Client Move Fix

### DIFF
--- a/client/src/Game/GamePage.js
+++ b/client/src/Game/GamePage.js
@@ -77,6 +77,14 @@ class GamePage extends Component {
             //select move
             move.toRow = i;
             move.toCol = j;
+            if (move.toRow === piece.row && move.toCol === piece.col) {
+                //user wants to cancel move
+                piece.row = null;
+                piece.col = null;
+                move.toRow = null;
+                move.toCol = null;
+                this.setState({selectedPiece: piece, chosenMove: move});
+            }
         }
         //execute the move if the selection/move process is complete
         if (move.toRow !== null && move.toCol !== null) {


### PR DESCRIPTION
It came to mind that if a user clicks the same square twice, they are trying to cancel their move. So, I reintroduced the check for a same-space move, so we don't waste time sending a "cancelled" move to the server