### PR TITLE
JungleBoard initialization 

### DIFF
--- a/server/src/main/java/com/jungleapp/cs414/server/JungleBoard.java
+++ b/server/src/main/java/com/jungleapp/cs414/server/JungleBoard.java
@@ -6,8 +6,23 @@ public class JungleBoard {
 
     public JungleBoard() { board = new Piece[9][7]; }
 
-    //TO-DO
     public void initialize() {
+        this.placePiece(new Lion(this, "RED"), "00");
+        this.placePiece(new Tiger(this, "RED"), "06");
+        this.placePiece(new Dog(this, "RED"), "11");
+        this.placePiece(new Cat(this,"RED"),"15");
+        this.placePiece(new Rat(this, "RED"),"20");
+        this.placePiece(new Leopard(this,"RED"),"22");
+        this.placePiece(new Wolf(this, "RED"), "24");
+        this.placePiece(new Elephant(this, "RED"), "26");
+
+        this.placePiece(new Lion(this, "BLUE"), "86");
+        this.placePiece(new Tiger(this, "BLUE"), "80");
+        this.placePiece(new Dog(this, "BLUE"), "75");
+        this.placePiece(new Cat(this,"BLUE"),"71");
+        this.placePiece(new Rat(this, "BLUE"),"66");
+        this.placePiece(new Leopard(this,"BLUE"),"64");
+        this.placePiece(new Wolf(this, "BLUE"), "62");
         this.placePiece(new Elephant(this,"BLUE"), "60");
 
     }

--- a/server/src/main/java/com/jungleapp/cs414/server/Piece.java
+++ b/server/src/main/java/com/jungleapp/cs414/server/Piece.java
@@ -55,7 +55,7 @@ public abstract class Piece {
         }
 
         //check right
-        if (column < 8) {
+        if (column < 6) {
             String checkRight = moveMaker(row, column+1);
             if (checkSpace(checkRight)) { moves.add(checkRight); }
         }

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/CatTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/CatTest.java
@@ -17,6 +17,19 @@ class CatTest {
     }
 
     @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("15").legalMoves().containsAll(Arrays.asList("05","25","14","16")));
+            assertTrue(board.getPiece("71").legalMoves().containsAll(Arrays.asList("81","61","72","70")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     void legalMoves() {
         JungleBoard board = new JungleBoard();
 

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/DogTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/DogTest.java
@@ -17,6 +17,19 @@ class DogTest {
     }
 
     @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("11").legalMoves().containsAll(Arrays.asList("01","21","10","12")));
+            assertTrue(board.getPiece("75").legalMoves().containsAll(Arrays.asList("74","76","65","85")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     void legalMoves() {
         JungleBoard board = new JungleBoard();
 

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/ElephantTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/ElephantTest.java
@@ -14,6 +14,19 @@ class ElephantTest {
         assertEquals(8, testElephant.getRank());
         assertEquals("RED", testElephant.getColor());
     }
+
+    @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("26").legalMoves().containsAll(Arrays.asList("16","25","36")));
+            assertTrue(board.getPiece("60").legalMoves().containsAll(Arrays.asList("50","61","70")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
     @Test
     public void testMoves() {
         JungleBoard board = new JungleBoard();

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/JungleBoardTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/JungleBoardTest.java
@@ -11,7 +11,25 @@ public class JungleBoardTest {
         JungleBoard board = new JungleBoard();
         board.initialize();
         try {
-            assertEquals(8,board.getPiece("60").getRank());
+            assertTrue(board.getPiece("00").getRank() == 7 && board.getPiece("00").getColor().equals("RED"));
+            assertTrue(board.getPiece("06").getRank() == 6 && board.getPiece("06").getColor().equals("RED"));
+            assertTrue(board.getPiece("11").getRank() == 4 && board.getPiece("11").getColor().equals("RED"));
+            assertTrue(board.getPiece("15").getRank() == 2 && board.getPiece("15").getColor().equals("RED"));
+            assertTrue(board.getPiece("20").getRank() == 1 && board.getPiece("20").getColor().equals("RED"));
+            assertTrue(board.getPiece("22").getRank() == 5 && board.getPiece("22").getColor().equals("RED"));
+            assertTrue(board.getPiece("24").getRank() == 3 && board.getPiece("24").getColor().equals("RED"));
+            assertTrue(board.getPiece("26").getRank() == 8 && board.getPiece("26").getColor().equals("RED"));
+
+
+            assertTrue(board.getPiece("60").getRank() == 8 && board.getPiece("60").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("62").getRank() == 3 && board.getPiece("62").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("64").getRank() == 5 && board.getPiece("64").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("66").getRank() == 1 && board.getPiece("66").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("71").getRank() == 2 && board.getPiece("71").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("75").getRank() == 4 && board.getPiece("75").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("80").getRank() == 6 && board.getPiece("80").getColor().equals("BLUE"));
+            assertTrue(board.getPiece("86").getRank() == 7 && board.getPiece("86").getColor().equals("BLUE"));
+
         } catch (IllegalPositionException e) {
             e.printStackTrace();
         }

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/LeopardTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/LeopardTest.java
@@ -16,6 +16,19 @@ class LeopardTest {
         assertEquals("RED", testLeopard.getColor());
     }
 
+
+    @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("22").legalMoves().containsAll(Arrays.asList("12","21","23")));
+            assertTrue(board.getPiece("64").legalMoves().containsAll(Arrays.asList("63","65","74")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
     @Test
     void legalMoves() {
         JungleBoard board = new JungleBoard();

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/LionTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/LionTest.java
@@ -17,6 +17,19 @@ public class LionTest {
     }
 
     @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("00").legalMoves().containsAll(Arrays.asList("10","01")));
+            assertTrue(board.getPiece("86").legalMoves().containsAll(Arrays.asList("85","76")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     public void legalMoves() {
         JungleBoard board = new JungleBoard();
 

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/RatTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/RatTest.java
@@ -17,6 +17,19 @@ class RatTest {
     }
 
     @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("20").legalMoves().containsAll(Arrays.asList("10","30","21")));
+            assertTrue(board.getPiece("66").legalMoves().containsAll(Arrays.asList("56","76","65")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     void legalMoves() {
         JungleBoard board = new JungleBoard();
 

--- a/server/src/serverTest/java/com/jungleapp/cs414/server/WolfTest.java
+++ b/server/src/serverTest/java/com/jungleapp/cs414/server/WolfTest.java
@@ -16,6 +16,20 @@ class WolfTest {
         assertEquals("RED", testWolf.getColor());
     }
 
+
+    @Test
+    public void testInitialMoves() {
+        JungleBoard board = new JungleBoard();
+        board.initialize();
+
+        try {
+            assertTrue(board.getPiece("24").legalMoves().containsAll(Arrays.asList("14","23","25")));
+            assertTrue(board.getPiece("62").legalMoves().containsAll(Arrays.asList("61","63","72")));
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+    }
+
     @Test
     void legalMoves() {
         JungleBoard board = new JungleBoard();


### PR DESCRIPTION
Initialize now places all pieces to the board in their initial position for a new game.  Add tests for each piece initial moves and tests that make sure the board is set up right. 

Also fixes a small bug in Legal moves where move right was checking as if the board had 9 columns instead of 7.